### PR TITLE
FIx de Error singleton al crear apuntes analíticos

### DIFF
--- a/analytic_partner/models/account_move_line.py
+++ b/analytic_partner/models/account_move_line.py
@@ -9,6 +9,10 @@ class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
     def _prepare_analytic_line(self):
-        res = super(AccountMoveLine, self)._prepare_analytic_line()
-        res[0]["other_partner_id"] = self.move_id.partner_id.commercial_partner_id.id
-        return res
+        values_list = super(AccountMoveLine, self)._prepare_analytic_line()
+        for index, move_line in enumerate(self):
+            values = values_list[index]
+            values[
+                "other_partner_id"
+            ] = move_line.move_id.partner_id.commercial_partner_id.id
+        return values_list


### PR DESCRIPTION
En la función de _prepare_analytic_line, cuando hay más de un move line da error de singleton