### PR TITLE
[FIX] hr_timesheet compat: exponer account_department_id en timesheets.analysis.report

### DIFF
--- a/analytic_base_department/__manifest__.py
+++ b/analytic_base_department/__manifest__.py
@@ -9,7 +9,7 @@
     "license": "AGPL-3",
     "category": "Generic Modules/Projects & Services",
     "website": "https://github.com/OCA/account-analytic",
-    "depends": ["account", "hr"],
+    "depends": ["account", "hr", "hr_timesheet"],
     "data": ["views/analytic.xml", "views/hr_department_views.xml"],
     "installable": True,
 }

--- a/analytic_base_department/models/__init__.py
+++ b/analytic_base_department/models/__init__.py
@@ -1,2 +1,3 @@
 from . import analytic
 from . import hr_department
+from . import hr_timesheet_report

--- a/analytic_base_department/models/hr_timesheet_report.py
+++ b/analytic_base_department/models/hr_timesheet_report.py
@@ -1,0 +1,24 @@
+from odoo import api, fields, models
+
+
+class TimesheetsAnalysisReport(models.Model):
+    """Expose account_department_id on the timesheets reporting SQL view.
+
+    hr_timesheet's own report search view (a "primary" view on this model)
+    inherits its arch from analytic.view_account_analytic_line_filter, the
+    same shared ancestor this module extends with account_department_id.
+    Without this field existing here too, that combination fails validating
+    as soon as both modules are installed together.
+    """
+
+    _inherit = "timesheets.analysis.report"
+
+    account_department_id = fields.Many2one(
+        comodel_name="hr.department",
+        string="Account Department",
+        readonly=True,
+    )
+
+    @api.model
+    def _select(self):
+        return super()._select() + ", A.account_department_id AS account_department_id"


### PR DESCRIPTION
[FIX] hr_timesheet compat: exponer account_department_id en el report SQL

analytic_base_department inserta account_department_id en la vista
compartida analytic.view_account_analytic_line_filter. hr_timesheet
tiene su propia vista de report (hr_timesheet_report_search), una
vista "primary" sobre el modelo SQL timesheets.analysis.report que
hereda su arch combinado de esa misma vista compartida -- pero ese
modelo de reporting solo expone un subconjunto de los campos de
account.analytic.line (no incluia account_department_id), asi que
la validacion de esa vista fallaba en cuanto ambos modulos estaban
instalados juntos (reproducido tanto en un install completo desde
cero como en un -u sobre una base de datos real ya migrada).

Fix: exponer account_department_id tambien en timesheets.analysis.report
(models/hr_timesheet_report.py), extendiendo _select() igual que ya
hace department_id. Requiere depender de hr_timesheet -- sin esa
dependencia explicita, analytic_base_department podia cargar antes que
hr_timesheet en el grafo de modulos, y la extension de este archivo
nunca llegaba a tiempo de evitar el fallo.

Nota: nubeaerp_004213 (Aures) tenia un workaround por su cuenta (quitar
el campo de la vista via xpath) que solo funcionaba si hr_timesheet ya
estaba instalado de antes en la base de datos -- fallaba igual en un
install limpio. Este fix en el modulo que origina el campo es la
solucion real, independiente del orden de instalacion.

---
Nota: esto crea drift respecto a OCA/account-analytic (1 commit propio, deliberado). Se documentará en el registro de forks de Dockyard.